### PR TITLE
Fix `schema_file_type` deprecation warning

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -32,7 +32,7 @@ module StandaloneMigrations
     end
 
     def initialize(options = {})
-      default_schema = ENV['SCHEMA'] || ActiveRecord::Tasks::DatabaseTasks.schema_file_type(ActiveRecord.schema_format)
+      default_schema = ENV['SCHEMA'] || "schema.rb"
       defaults = {
         :config       => "db/config.yml",
         :migrate_dir  => "db/migrate",


### PR DESCRIPTION
Didn't find a better method that doesn't try to load more of the Rails application that this project intends to avoid, so just added the literal default value instead.

https://edgeguides.rubyonrails.org/7_1_release_notes.html
  - 8.1 Removals
    - Remove deprecated Tasks::DatabaseTasks.schema_file_type.